### PR TITLE
Fix garbled Unicode in VAD client message

### DIFF
--- a/src_v1/vad_client.py
+++ b/src_v1/vad_client.py
@@ -19,7 +19,7 @@ class VADRealtimeClient(RealtimeOpenAIClient):
         """
         Record audio with VAD - stops automatically when no speech detected
         """
-        print("�� เริ่มฟังเสียง (พูดได้เลย)...")
+        print("🎤 เริ่มฟังเสียง (พูดได้เลย)...")
         
         audio_buffer = b''
         last_speech_time = time.time()


### PR DESCRIPTION
## Summary
- clean up garbled text at startup message in `VADRealtimeClient`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68712ce6061483328c33d8430f1cfe2f